### PR TITLE
build-split-vf: run fix-vf-meta on individual families

### DIFF
--- a/sources/scripts/build-split-vf.sh
+++ b/sources/scripts/build-split-vf.sh
@@ -62,7 +62,7 @@ subsetSmallCaps()
 
     echo making ${smallCapFontName}.ttf
 
-    pyftfeatfreeze.py -f 'smcp' -S -U SC $FILE $SC_NAME
+    python pyftfeatfreeze.py -f 'smcp' -S -U SC $FILE $SC_NAME
 
     ttx $FILE
     ttxPath=${FILE/".ttf"/".ttx"}
@@ -135,13 +135,11 @@ if [ -f "$file" ]; then
     rm -rf $ttxPath
 
     ## Marc's solution to fix VF metadata
-    # gftools fix-vf-meta $file
+    gftools fix-vf-meta $file
+    mv "$file.fix" $file
 fi
 done
 
-## Marc's solution to fix VF metadata
-vfs=$(ls variable_ttf/*-VF.ttf)
-gftools fix-vf-meta $vfs;
 
 # ============================================================================
 # Sort into final folder =====================================================


### PR DESCRIPTION
gftools-fix-vf-meta can only be run on a single family. You were attempting to run it on both the Condensed and SemiCondensed families at the same time.

It may be nice to include pyftfeatfreeze.py as a script in this repo. I had to find it and bundle it into this repo.

Rerun your build chain once https://github.com/googlefonts/gftools/pull/109 has been merged.